### PR TITLE
refactor : S3 이미지 업로드 경로 도메인별 분리

### DIFF
--- a/Mavis-Admin/src/main/java/com/mavis/admin/domains/product/implement/ProductImageAppender.java
+++ b/Mavis-Admin/src/main/java/com/mavis/admin/domains/product/implement/ProductImageAppender.java
@@ -4,6 +4,7 @@ import com.mavis.domain.domains.product.domain.Product;
 import com.mavis.domain.domains.product.domain.ProductImage;
 import com.mavis.domain.domains.product.domain.ProductImageType;
 import com.mavis.domain.domains.product.repository.ProductImageRepository;
+import com.mavis.infrastructure.image.ImageDirectory;
 import com.mavis.infrastructure.image.S3FileUploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -21,21 +22,21 @@ public class ProductImageAppender {
     public void saveImages(List<MultipartFile> mainImages, List<MultipartFile> productImages, List<MultipartFile> detailImages, Product product) {
         //메인
         List<String> uploadedMainImages = mainImages.stream()
-                .map(s3FileUploader::uploadImageToS3)
+                .map(image -> s3FileUploader.uploadImageToS3(image, ImageDirectory.PRODUCT))
                 .toList();
         List<ProductImage> mainProductImages = mapProductImagesInOrder(uploadedMainImages, product, ProductImageType.MAIN);
         productImageRepository.saveAll(mainProductImages);
 
         //상품
         List<String> uploadedProductImages = productImages.stream()
-                .map(s3FileUploader::uploadImageToS3)
+                .map(image -> s3FileUploader.uploadImageToS3(image, ImageDirectory.PRODUCT))
                 .toList();
         List<ProductImage> productImageEntities = mapProductImagesInOrder(uploadedProductImages, product, ProductImageType.PRODUCT);
         productImageRepository.saveAll(productImageEntities);
 
         //상품 상세
         List<String> detailProductImageUrls = detailImages.stream()
-                .map(s3FileUploader::uploadImageToS3)
+                .map(image -> s3FileUploader.uploadImageToS3(image, ImageDirectory.PRODUCT))
                 .toList();
         List<ProductImage> productDetailImages = mapProductImagesInOrder(detailProductImageUrls, product, ProductImageType.DETAIL);
         productImageRepository.saveAll(productDetailImages);

--- a/Mavis-Admin/src/main/java/com/mavis/admin/domains/product/service/AdminProductService.java
+++ b/Mavis-Admin/src/main/java/com/mavis/admin/domains/product/service/AdminProductService.java
@@ -9,6 +9,7 @@ import com.mavis.domain.domains.product.repository.ProductImageRepository;
 import com.mavis.domain.domains.product.repository.ProductNoticeRepository;
 import com.mavis.domain.domains.product.repository.ProductRepository;
 import com.mavis.domain.domains.product.vo.ColorVO;
+import com.mavis.infrastructure.image.ImageDirectory;
 import com.mavis.infrastructure.image.S3FileUploader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -164,7 +165,7 @@ public class AdminProductService {
             if (multipartFile == null || multipartFile.isEmpty()) {
                 continue;
             }
-            String uploadImageUrl = s3FileUploader.uploadImageToS3(multipartFile);
+            String uploadImageUrl = s3FileUploader.uploadImageToS3(multipartFile, ImageDirectory.PRODUCT);
 
             ProductImage productImage = ProductImage.builder()
                     .product(product)

--- a/Mavis-Api/src/main/java/com/mavis/api/inquiry/implement/InquiryImageAppender.java
+++ b/Mavis-Api/src/main/java/com/mavis/api/inquiry/implement/InquiryImageAppender.java
@@ -3,6 +3,7 @@ package com.mavis.api.inquiry.implement;
 import com.mavis.domain.domains.inquiry.domain.Inquiry;
 import com.mavis.domain.domains.inquiry.domain.InquiryImage;
 import com.mavis.domain.domains.inquiry.repository.InquiryImageRepository;
+import com.mavis.infrastructure.image.ImageDirectory;
 import com.mavis.infrastructure.image.S3FileUploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -20,7 +21,7 @@ public class InquiryImageAppender {
     public void saveInquiryImages(Inquiry inquiry, List<MultipartFile> images) {
         List<InquiryImage> inquiryImages = images.stream()
                 .map(image -> {
-                    String imageUrl = s3FileUploader.uploadImageToS3(image);
+                    String imageUrl = s3FileUploader.uploadImageToS3(image, ImageDirectory.INQUIRY);
                     return InquiryImage.builder()
                             .imageUrl(imageUrl)
                             .inquiry(inquiry)

--- a/Mavis-Api/src/main/java/com/mavis/api/refund/implement/RefundImageUploader.java
+++ b/Mavis-Api/src/main/java/com/mavis/api/refund/implement/RefundImageUploader.java
@@ -3,6 +3,7 @@ package com.mavis.api.refund.implement;
 import com.mavis.domain.domains.refund.domain.Refund;
 import com.mavis.domain.domains.refund.domain.RefundImage;
 import com.mavis.domain.domains.refund.repository.RefundImageRepository;
+import com.mavis.infrastructure.image.ImageDirectory;
 import com.mavis.infrastructure.image.S3FileUploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -20,7 +21,7 @@ public class RefundImageUploader {
     public void saveRefundImages(List<MultipartFile> images, Refund refund) {
         List<RefundImage> refundImages = images.stream()
                 .map(image -> {
-                    String imageUrl = fileUploader.uploadImageToS3(image);
+                    String imageUrl = fileUploader.uploadImageToS3(image, ImageDirectory.REFUND);
                     return RefundImage.builder()
                             .imageUrl(imageUrl)
                             .refund(refund)

--- a/Mavis-Api/src/main/java/com/mavis/api/review/implement/ReviewImageUploader.java
+++ b/Mavis-Api/src/main/java/com/mavis/api/review/implement/ReviewImageUploader.java
@@ -3,6 +3,7 @@ package com.mavis.api.review.implement;
 import com.mavis.domain.domains.review.domain.Review;
 import com.mavis.domain.domains.review.domain.ReviewImage;
 import com.mavis.domain.domains.review.repository.ReviewImageRepository;
+import com.mavis.infrastructure.image.ImageDirectory;
 import com.mavis.infrastructure.image.S3FileUploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -30,7 +31,7 @@ public class ReviewImageUploader {
         List<ReviewImage> reviewImages = images.stream()
                 .map(
                         image -> {
-                            String imageUrl = fileUploader.uploadImageToS3(image);
+                            String imageUrl = fileUploader.uploadImageToS3(image, ImageDirectory.REVIEW);
                             return ReviewImage.builder()
                                     .imageUrl(imageUrl)
                                     .review(review)

--- a/Mavis-Infrastructure/src/main/java/com/mavis/infrastructure/image/ImageDirectory.java
+++ b/Mavis-Infrastructure/src/main/java/com/mavis/infrastructure/image/ImageDirectory.java
@@ -1,0 +1,18 @@
+package com.mavis.infrastructure.image;
+
+public enum ImageDirectory {
+    REVIEW("review"),
+    REFUND("refund"),
+    INQUIRY("inquiry"),
+    PRODUCT("product");
+
+    private final String path;
+
+    ImageDirectory(String path) {
+        this.path = path;
+    }
+
+    public String getPath() {
+        return path;
+    }
+}

--- a/Mavis-Infrastructure/src/main/java/com/mavis/infrastructure/image/S3FileUploader.java
+++ b/Mavis-Infrastructure/src/main/java/com/mavis/infrastructure/image/S3FileUploader.java
@@ -24,10 +24,10 @@ public class S3FileUploader {
     @Value("${aws.s3.bucket-name}")
     private String bucketName;
 
-    public String uploadImageToS3(MultipartFile file) {
+    public String uploadImageToS3(MultipartFile file, ImageDirectory directory) {
         String originalFilename = file.getOriginalFilename();
         String extension = Objects.requireNonNull(originalFilename).substring(originalFilename.lastIndexOf(".") + 1);
-        String s3FileName = UUID.randomUUID().toString().substring(0, 10) + "_" + originalFilename;
+        String s3FileName = directory.getPath() + "/" + UUID.randomUUID().toString().substring(0, 10) + "_" + originalFilename;
 
         try (InputStream inputStream = file.getInputStream()) {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()


### PR DESCRIPTION
ImageDirectory enum 추가 및 uploadImageToS3에 directory 파라미터 적용으로 review/refund/inquiry/product 폴더별로 S3 경로 구분